### PR TITLE
ZENREACH-182: New Client With Host Function

### DIFF
--- a/plivo/plivo.go
+++ b/plivo/plivo.go
@@ -16,7 +16,8 @@ import (
 
 const (
 	libraryVersion = "0.1"
-	defaultBaseURL = "https://api.plivo.com/%s/Account/"
+	defaultHost    = "api.plivo.com"
+	defaultBaseURL = "https://%s/%s/Account/"
 	userAgent      = "go-plivo/" + libraryVersion
 	apiVersion     = "v1"
 )
@@ -47,7 +48,12 @@ type Client struct {
 
 // NewClient returns a new Plivo API client. If client is nil, http.DefaultClient will be used.
 func NewClient(client *http.Client, authID, authToken string) *Client {
-	baseURL, _ := url.Parse(fmt.Sprintf(defaultBaseURL, apiVersion))
+	return NewClientWithHost(client, authID, authToken, defaultHost)
+}
+
+// NewClientWithHost returns a new Plivo API client with specified host.
+func NewClientWithHost(client *http.Client, authID, authToken string, host string) *Client {
+	baseURL, _ := url.Parse(fmt.Sprintf(defaultBaseURL, host, apiVersion))
 
 	if client == nil {
 		client = http.DefaultClient

--- a/plivo/plivo_test.go
+++ b/plivo/plivo_test.go
@@ -3,6 +3,7 @@ package plivo
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -44,6 +45,12 @@ func setup() {
 	FromNumber = config["from_number"]
 	ToNumber = config["to_number"]
 	AnswerURL = config["answer_url"]
+}
+
+func TestNewClientURL(t *testing.T) {
+	expectedClientURL := "https://api.plivo.com/v1/Account/"
+	client := NewClient(nil, authID, authToken)
+	assert.Equal(t, client.BaseURL.String(), expectedClientURL, "urls should be equal")
 }
 
 func TestAccountGet(t *testing.T) {


### PR DESCRIPTION
added client function that can take in a different host (for mocking) without affecting current use of NewClient function